### PR TITLE
feat add posting registration, post bill, ship address

### DIFF
--- a/src/bodyObjects/ReggistrationFields.tsx
+++ b/src/bodyObjects/ReggistrationFields.tsx
@@ -1,0 +1,20 @@
+export const RegObj = {
+  version: 1,
+  // если повторно отправлять запрос к тому же кастомеру(если надо еще что-то добавить), надо увеличивать version на 1
+  actions: [
+    { action: 'setLastName', lastName: 'myNewFamilia' },
+    { action: 'setFirstName', firstName: 'myNewName' },
+    { action: 'setDateOfBirth', dateOfBirth: '1990-11-21' },
+    {
+      action: 'addAddress',
+      address: {
+        streetName: 'Wall2 Street',
+        streetNumber: '2585',
+        postalCode: '22229',
+        city: 'New York city',
+        country: 'US',
+      },
+    },
+    // можно еще добавить необходимые поля
+  ],
+};

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -1,13 +1,14 @@
 import { FC } from 'react';
 
 import './Login.scss';
+import { RegObj } from '../bodyObjects/ReggistrationFields';
 import { getToken, getInProject, setInProject } from '../client_Api';
 
 const Login: FC = () => {
   const validation = async () => {
     const requestBody = {
-      email: 'hancharuk345678@mail.ru',
-      password: '#Qwerty888888$',
+      email: 'mamama@mail.ru',
+      password: '#Qwerty8234$',
     };
 
     const objToken = await getToken();
@@ -15,9 +16,42 @@ const Login: FC = () => {
     //   console.log(responce)
     // );
 
-    getInProject(objToken, 'customers/6afb3d83-3f25-4540-a456-6ee7592a9ad1').then(responce =>
-      console.log(responce)
-    );
+    // отправка полей из формы регистрации в commercetools
+    // оставляю закоментированным, т.к. приходит ошибка для одних и тех же данных
+
+    // setInProject(
+    //   objToken,
+    //   'customers/2119541f-de45-47fe-bed1-4c8d09c93b44',
+    //   JSON.stringify(RegObj)
+    // ).then(responce => {
+    //   console.log(responce.addresses);
+    //   return responce.addresses;
+    // });
+
+    getInProject(objToken, 'customers').then(responce => console.log(responce));
+
+    // установка адреса в качестве адреса доставки и юридического адреса
+
+    getInProject(objToken, 'customers/2119541f-de45-47fe-bed1-4c8d09c93b44').then(responce => {
+      console.log(responce);
+      console.log(responce.addresses);
+      setInProject(
+        objToken,
+        'customers/2119541f-de45-47fe-bed1-4c8d09c93b44',
+        JSON.stringify({
+          version: 8, // повторные запросы по тем же кастомерам
+          actions: [{ action: 'addShippingAddressId', addressId: responce.addresses[0].id }],
+        })
+      );
+      setInProject(
+        objToken,
+        'customers/2119541f-de45-47fe-bed1-4c8d09c93b44',
+        JSON.stringify({
+          version: 8, // повторные запросы по тем же кастомерам
+          actions: [{ action: 'addBillingAddressId', addressId: responce.addresses[1].id }],
+        })
+      );
+    });
     return;
   };
 


### PR DESCRIPTION
1. добавила папку bodyObjects. В ней файл с объектом в котором описаны поля кастомера которые будем заполнять
2. в файле login.tsx закоментированная функция с описанием к ней. Можешь придумать нового кастомера(почта, пароль) тогда функция заработает(т.е. создаст на commercetools кастомера с полями из файла reggistrationField)
3. Функция установки адресов доставки и юридического адреса тоже работает.
4. Увидишь поля "version: 8" - номер меняла вручную при каждом запросе по одним и тем же данным, чтобы ошибки не вылазили. По идее при создании кастомера будут только "version: 1"
5. Результат проверяла на commercetools, вот что в итоге получилось у меня: 
![image](https://github.com/mikhaelHan/react_Api/assets/98157246/d3729607-67b6-4698-8b14-38dd9d363273)
